### PR TITLE
Reference in default template for record detail.

### DIFF
--- a/components/recorddetail/default.htm
+++ b/components/recorddetail/default.htm
@@ -1,7 +1,7 @@
 <div class="record-box {{ cssClass }}">
 
     {% if __SELF__.recordDetail.preview_image %}
-        <img alt="{{ __SELF__.name }}" src="{{ __SELF__.preview_image.getPath }}" />
+        <img alt="{{ __SELF__.recordDetail.name }}" src="{{ __SELF__.recordDetail.preview_image.getPath() }}" />
     {% endif %}
 
     <h3 class="record-box-title">


### PR DESCRIPTION
The featured image shows as a broken image due to the incorrect Twig markup in the img tag.