### PR TITLE
Fixed wrong link in the breadcrumbs on Attribute edit form.

### DIFF
--- a/controllers/attributes/update.htm
+++ b/controllers/attributes/update.htm
@@ -1,6 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
-        <li><a href="<?= Backend::url('janvince/smallrecords/posts') ?>"><?= e(trans('janvince.smallrecords::lang.attributes.menu_label')) ?></a></li>
+        <li><a href="<?= Backend::url('janvince/smallrecords/attributes') ?>"><?= e(trans('janvince.smallrecords::lang.attributes.menu_label')) ?></a></li>
         <li><?= e(trans($this->pageTitle)) ?></li>
     </ul>
 <?php Block::endPut() ?>


### PR DESCRIPTION
Very simple one-line bug fix

![screen](https://user-images.githubusercontent.com/987517/69433238-4e445c80-0d4c-11ea-9f4b-6f7dd04362bc.png)