### PR TITLE
Add short alias for isActive scope

### DIFF
--- a/models/Record.php
+++ b/models/Record.php
@@ -143,6 +143,17 @@ class Record extends Model
 
         return $query->where('favourite', '=', true);
     }
+    
+    /**
+     * Scope records by active value.
+     * 
+     * Short alias for scope isActive with option
+     * 
+     * @param boolean $value active value, default TRUE
+     */
+    public function scopeActive($query, $value = true) {
+        return $query->where('active', $value);
+    }
 
     /**
     *    FILTERS


### PR DESCRIPTION
Concise, convenient, with the ability to return an inverted result.

Name `active` for this scope mentioned in OctoberCMS documentation:
https://octobercms.com/docs/database/model#query-scopes

This short name is also often found in the implementation of models of other plugins.

```php
Record::active()->paginate(12);
```

You can also invert the result by passing FALSE. What for? I don’t know, but why not =)

```php
Record::active(false)->paginate(12);
```